### PR TITLE
IS-721: Support for tracker

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ NAME: Not an empty string
     * [getServiceConfig](#getserviceconfig)
     * [getRevision](#getrevision)
     * [getProposal](#getproposal)
-    * [getProposalList](#getproposallist)
+    * [getProposals](#getproposals)
 * Invoke methods
     * [acceptScore](#acceptscore)
     * [rejectScore](#rejectscore)
@@ -715,27 +715,41 @@ None
     "jsonrpc": "2.0",
     "id": 100,
     "result": {
-        "proposer" : "hxbe258ceb872e08851f1f59694dac2558708ece11",
-        "id" : "0xb903239f8543d04b5dc1ba6579132b143087c68db1b2168786408fcbce568238",
-        "status" : "0x0",
+        "id" : "0xb903239f8543d0..",
+        "proposer" : "hxbe258ceb872e08851f1f59694dac2558708ece11",  
+      	"proposerName" : "Proposer1",
+      	"status" : "0x0",
         "startBlockHeight" : "0x1",
         "endBlockHeight" : "0x65",
-        "voter": {
+        "vote": {
             "agree": {
-                "address": ["hxe7af5fcfd8dfc67530a01a0e403882687528dfcb", "hxe7af5fcfd8dfc67530a01a0e403882687528dfcb"],
+                "list":[{
+                    "id": "0xb903239f854..",
+                    "timestamp": "0x563a6cf330136",
+                    "address": "hxe7af5fcfd8dfc67530a01a0e403882687528dfcb",
+                    "name": "Proposal2",
+                    "amount": "0x1"
+                }, .. ],
                 "amount": "0x12345"
             },
             "disagree": {
-                "address": ["hxbe258ceb872e08851f1f59694dac2558708ece11"],
+                "list": [{
+                    "id": "0xa803239f854..",
+                    "timestamp": "0x563a6cf330136",
+                    "address": "hxe7af5fcfd8dfc67530a01a0e403882687528dfcb",
+                    "name": "Proposal3",
+                    "amount": "0x1"
+                }, .. ],
                 "amount": "0x123"
             },
             "noVote": {
-                "address": ["hx31258ceb872e08851f1f59694dac2558708ece11", .. , "hx31258ceb872e08851f1f59694dac2558708eceff"],
+                "list": ["hx31258ceb872e08851f1f59694dac2558708ece11", .. , "hx31258ceb872e08851f1f59694dac2558708eceff"],
                 "amount": "0x12312341234a"
             },
         },
         "contents": {
-            "description": "Disqualify P-Rep A; P-Rep A does not maintain node",
+          	"title": "Disqualify P-Rep A",
+            "description": "P-Rep A does not maintain node",
             "type": "0x3",
             "value": {
                 "address": "hxbe258ceb872e08851f1f59694dac2558708ece11"
@@ -745,7 +759,7 @@ None
 }
 ```
 
-## getProposalList
+## getProposals
 
 * Query all of the network proposals.
 
@@ -776,7 +790,7 @@ None
         "timestamp": "0x563a6cf330136",
         "dataType": "call",
         "data": {
-            "method": "getProposalList",
+            "method": "getProposals",
             "params": {
                 "type": "0x3",
                 "status": "0x0"
@@ -789,27 +803,42 @@ None
 #### Response
 
 ```json
-{
-    "jsonrpc": "2.0",
-    "id": 100,
-    "result": {
-        "proposals" : [
-            {
-                "description": "(1) Disqualify P-Rep A; P-Rep A does not maintain node",
-                "type": "0x3",
-                "status" : "0x0",
-                "startBlockHeight": "0x1",
-                "endBlockHeight" : "0x65"
+{  
+   "jsonrpc":"2.0",
+   "id":1234,
+   "result":{  
+      "proposals":[  
+         {  
+            "id":"0xb903239f8543..",
+            "proposer":"hxbe258ceb872e08851f1f59694dac2558708ece11",
+            "proposerName":"Proposer1",
+            "status":"0x0",
+            "startBlockHeight":"0x1",
+            "endBlockHeight":"0x65",
+            "vote":{  
+               "agree":{  
+                  "count":"0x1",
+                  "amount":"0x12312341234a"
+               },
+               "disagree":{  
+                  "count":"0x1",
+                  "amount":"0x12312341234a"
+               },
+               "noVote":{  
+                  "count":"0x1",
+                  "amount":"0x12312341234a"
+               }
             },
-           {
-                "description": "(2) Disqualify P-Rep B; P-Rep B does not maintain node",
-                "type": "0x3",
-                "status" : "0x0",
-                "startBlockHeight": "0x2",
-                "endBlockHeight" : "0x65"
+            "contents":{  
+               "title":"Disqualify P-Rep A",
+               "description":"P-Rep A does not maintain node",
+               "type":"0x3",
+               "value":{  
+                  "address":"hxbe258ceb872e08851f1f59694dac2558708ece11"
+               }
             }
-        ]
-    }
+         }, .. ]
+   }
 }
 ```
 
@@ -907,14 +936,15 @@ Invoke method can initiate state transition.
 
 | Key | Value Type | Description |
 |:----|:-----------|-----|
-| description | [T\_STR](#T_STR) | Description of the network proposal |
-| type | [T\_INT](#T_INT) | Type of the network proposal |
-| value | T\_DICT | Values for each type of network proposal. Hex string of UTF-8 encoded bytes data of JSON string<br />ex. "0x" + bytes.hex(json.dumps(value).encode()) |
+| title | [T\_STR](#T_STR) | Title of the network proposal |
+| description | [T\_STR](#T_STR) | Description of the network proposal                          |
+| type        | [T\_INT](#T_INT) | Type of the network proposal                                 |
+| value | T\_DICT          | Values for each type of network proposal. Hex string of UTF-8 encoded bytes data of JSON string<br />ex. "0x" + bytes.hex(json.dumps(value).encode()) |
 
 #### value for type 0x0 (Text)
 | Key | Value Type | Description |
 |:----|:-----------|-----|
-| text | [T\_STR](#T_STR) | Text value |
+| value | [T\_STR](#T_STR) | Text value |
 
 #### value for type 0x1 (Revision)
 | Key | Value Type | Description |
@@ -945,25 +975,25 @@ Invoke method can initiate state transition.
 ```json
 {
     "jsonrpc": "2.0",
-    "id": 100,
+    "id": 1234,
     "method": "icx_sendTransaction",
     "params": {
         "version": "0x3",
-        "from": "hxbe258ceb872e08851f1f59694dac2558708ece11",
+        "from": "hx8f21e5c54f006b6a5d5fe65486908592151a7c57",
         "to": "cx0000000000000000000000000000000000000001",
-        "stepLimit": "0x30000",
+        "stepLimit": "0x12345",
         "timestamp": "0x563a6cf330136",
-        "nonce": "0x1",
-        "signature": "VAia7YZ2Ji6igKWzjR2YsGa2m53nKPrfK7uXYW78QLE+ATehAVZPC40szvAiA6NEU5gCYB4c4qaQzqDh2ugcHgA=",
+        "nid": "0x3",
+        "nonce": "0x0",
+        "signature": "VAia7YZ2Ji6igKWzjR2YsGa2m5...",
         "dataType": "call",
         "data": {
             "method": "registerProposal",
             "params": {
-                "description": "Disqualify P-Rep A; P-Rep A does not maintain node",
-                "type": "0x0",
-                "value": {
-                  "text": "0x7b2261646472657373223a2022687865..."
-                }
+                "title": "Disqualify P-Rep A",
+                "description": "P-Rep A does not maintain node",
+                "type": "0x3",
+                "value": "0x7b2261646472657373223a2022.."
             }
         }
     }
@@ -1127,7 +1157,7 @@ Triggered on any successful registerProposal transaction.
 
 ```python
 @eventlog(indexed=0)
-def RegisterNetworkProposal(self, description: str, type: int, value: bytes, proposer: Address):
+def RegisterNetworkProposal(self, title: str, description: str, type: int, value: bytes, proposer: Address):
     pass
 ```
 

--- a/README.md
+++ b/README.md
@@ -717,7 +717,7 @@ None
     "result": {
         "id" : "0xb903239f8543d0..",
         "proposer" : "hxbe258ceb872e08851f1f59694dac2558708ece11",  
-      	"proposerName" : "Proposer1",
+      	"proposerName" : "P-Rep A",
       	"status" : "0x0",
         "startBlockHeight" : "0x1",
         "endBlockHeight" : "0x65",
@@ -727,7 +727,7 @@ None
                     "id": "0xb903239f854..",
                     "timestamp": "0x563a6cf330136",
                     "address": "hxe7af5fcfd8dfc67530a01a0e403882687528dfcb",
-                    "name": "Proposal2",
+                    "name": "P-Rep B",
                     "amount": "0x1"
                 }, .. ],
                 "amount": "0x12345"
@@ -736,8 +736,8 @@ None
                 "list": [{
                     "id": "0xa803239f854..",
                     "timestamp": "0x563a6cf330136",
-                    "address": "hxe7af5fcfd8dfc67530a01a0e403882687528dfcb",
-                    "name": "Proposal3",
+                    "address": "hxbe258ceb872e08851f1f59694dac2558708ece11",
+                    "name": "P-Rep C",
                     "amount": "0x1"
                 }, .. ],
                 "amount": "0x123"
@@ -748,8 +748,8 @@ None
             },
         },
         "contents": {
-          	"title": "Disqualify P-Rep A",
-            "description": "P-Rep A does not maintain node",
+            "title": "Disqualify P-Rep C",
+            "description": "P-Rep C does not maintain node",
             "type": "0x3",
             "value": {
                 "address": "hxbe258ceb872e08851f1f59694dac2558708ece11"
@@ -811,7 +811,7 @@ None
          {  
             "id":"0xb903239f8543..",
             "proposer":"hxbe258ceb872e08851f1f59694dac2558708ece11",
-            "proposerName":"Proposer1",
+            "proposerName":"P-Rep A",
             "status":"0x0",
             "startBlockHeight":"0x1",
             "endBlockHeight":"0x65",
@@ -830,8 +830,8 @@ None
                }
             },
             "contents":{  
-               "title":"Disqualify P-Rep A",
-               "description":"P-Rep A does not maintain node",
+               "title":"Disqualify P-Rep C",
+               "description":"P-Rep C does not maintain node",
                "type":"0x3",
                "value":{  
                   "address":"hxbe258ceb872e08851f1f59694dac2558708ece11"

--- a/governance/governance.py
+++ b/governance/governance.py
@@ -153,7 +153,7 @@ class Governance(IconSystemScoreBase):
         pass
 
     @eventlog(indexed=0)
-    def RegisterNetworkProposal(self, description: str, type: int, value: bytes, proposer: Address):
+    def RegisterNetworkProposal(self, title: str, description: str, type: int, value: bytes, proposer: Address):
         pass
 
     @eventlog(indexed=0)
@@ -677,9 +677,10 @@ class Governance(IconSystemScoreBase):
         return {'code': self._revision_code.get(), 'name': self._revision_name.get()}
 
     @external
-    def registerProposal(self, description: str, type: int, value: bytes):
+    def registerProposal(self, title: str, description: str, type: int, value: bytes):
         """ Register a Proposal with information like description, type and value by main prep
 
+        :param title: title of the proposal
         :param description: description of the proposal
         :param type: proposal type
         :param value: encoded value
@@ -695,9 +696,9 @@ class Governance(IconSystemScoreBase):
 
         value_in_dict = json_loads(value.decode())
         self._network_proposal.register_proposal(self.tx.hash, self.msg.sender, self.block_height, expire_block_height,
-                                                 description, type, value_in_dict, main_preps)
+                                                 title, description, type, value_in_dict, main_preps)
 
-        self.RegisterNetworkProposal(description, type, value, self.msg.sender)
+        self.RegisterNetworkProposal(title, description, type, value, self.msg.sender)
 
     @external
     def cancelProposal(self, id: bytes):
@@ -763,14 +764,14 @@ class Governance(IconSystemScoreBase):
         return proposal_info
 
     @external(readonly=True)
-    def getProposalList(self, type: int = None, status: int = None) -> dict:
+    def getProposals(self, type: int = None, status: int = None) -> dict:
         """ Get all of proposals in list
 
         :param type: type of network proposal to filter (optional)
         :param status: status of network proposal to filter (optional)
         :return: proposal list in dict
         """
-        return self._network_proposal.get_proposal_list(self.block_height, type, status)
+        return self._network_proposal.get_proposals(self.block_height, type, status)
 
     def _check_main_prep(self, address: 'Address', main_preps: list) -> bool:
         """ Check if the address is main prep

--- a/governance/tests/test_integration_test_network_proposal.py
+++ b/governance/tests/test_integration_test_network_proposal.py
@@ -237,6 +237,7 @@ class TestNetworkProposal(IconIntegrateTestBase):
 
     @staticmethod
     def _create_register_proposal_tx(key_wallet: 'KeyWallet',
+                                     title: str,
                                      desc: str,
                                      type: int,
                                      value_dict: dict,
@@ -245,6 +246,7 @@ class TestNetworkProposal(IconIntegrateTestBase):
                                      nid: int = DEFAULT_NID,
                                      nonce: int = 0) -> 'SignedTransaction':
         params = {
+            "title": title,
             "description": desc,
             "type": hex(type),
             "value": "0x" + bytes.hex(json.dumps(value_dict).encode())
@@ -426,9 +428,10 @@ class TestNetworkProposal(IconIntegrateTestBase):
 
         # register proposal
         proposer = self._test1
+        title = "test title"
         desc = 'test proposal'
         value = 'hello world'
-        tx = self._create_register_proposal_tx(proposer, desc, NetworkProposalType.TEXT, {"text": value})
+        tx = self._create_register_proposal_tx(proposer, title, desc, NetworkProposalType.TEXT, {"value": value})
         response = self.process_transaction(tx, self.icon_service)
         self.assertTrue('status' in response and 1 == response['status'],
                         f"TX:\n{tx.signed_transaction_dict}\nTX_RESULT:\n{response}")
@@ -440,7 +443,7 @@ class TestNetworkProposal(IconIntegrateTestBase):
         self.assertEqual(np_id, response['id'], response)
         self.assertEqual(desc, response['contents']['description'], response)
         self.assertEqual(hex(NetworkProposalType.TEXT), response['contents']['type'], response)
-        self.assertEqual(value, response['contents']['value']['text'], response)
+        self.assertEqual(value, response['contents']['value']['value'], response)
 
         # vote - agree
         tx = self._create_vote_proposal_tx(proposer, np_id, NetworkProposalVote.AGREE)
@@ -476,9 +479,10 @@ class TestNetworkProposal(IconIntegrateTestBase):
 
         # register proposal
         proposer = self._test1
+        title = "test title"
         desc = 'test proposal'
         value = 'hello world'
-        tx = self._create_register_proposal_tx(proposer, desc, NetworkProposalType.TEXT, {"text": value})
+        tx = self._create_register_proposal_tx(proposer, title, desc, NetworkProposalType.TEXT, {"value": value})
         response = self.process_transaction(tx, self.icon_service)
         np_id = response['txHash']
 
@@ -504,9 +508,10 @@ class TestNetworkProposal(IconIntegrateTestBase):
 
         # register proposal
         proposer = self._test1
+        title = "test title"
         desc = 'test proposal'
         value = 'hello world'
-        tx = self._create_register_proposal_tx(proposer, desc, NetworkProposalType.TEXT, {"text": value})
+        tx = self._create_register_proposal_tx(proposer, title, desc, NetworkProposalType.TEXT, {"value": value})
         response = self.process_transaction(tx, self.icon_service)
         np_id = response['txHash']
 
@@ -543,9 +548,10 @@ class TestNetworkProposal(IconIntegrateTestBase):
 
         # register proposal
         proposer = self._test1
+        title = "test title"
         desc = 'test proposal'
         value = 'hello world'
-        tx = self._create_register_proposal_tx(proposer, desc, NetworkProposalType.TEXT, {"text": value})
+        tx = self._create_register_proposal_tx(proposer, title, desc, NetworkProposalType.TEXT, {"value": value})
         response = self.process_transaction(tx, self.icon_service)
         np_id = response['txHash']
 
@@ -571,9 +577,10 @@ class TestNetworkProposal(IconIntegrateTestBase):
 
         # register proposal
         proposer = self._test1
+        title = "test title"
         desc = 'test proposal'
         value = 'hello world'
-        tx = self._create_register_proposal_tx(proposer, desc, NetworkProposalType.TEXT, {"text": value})
+        tx = self._create_register_proposal_tx(proposer, title, desc, NetworkProposalType.TEXT, {"value": value})
         response = self.process_transaction(tx, self.icon_service)
         np_id = response['txHash']
 
@@ -610,11 +617,12 @@ class TestNetworkProposal(IconIntegrateTestBase):
 
         # register proposal
         proposer = self._test1
+        title = "test title"
         desc = 'revision update network proposal'
         code = 10
         name = "for revision update network proposal test"
         value = {"code": hex(code), "name": name}
-        tx = self._create_register_proposal_tx(proposer, desc, NetworkProposalType.REVISION, value)
+        tx = self._create_register_proposal_tx(proposer, title, desc, NetworkProposalType.REVISION, value)
         response = self.process_transaction(tx, self.icon_service)
         np_id = response['txHash']
 
@@ -640,10 +648,11 @@ class TestNetworkProposal(IconIntegrateTestBase):
 
         # register proposal - freeze SCORE
         proposer = self._test1
+        title = "test title"
         desc = 'Malicious SCORE network proposal'
         address = f"cxa23{'0' * 37}"
         value = {"address": address, "type": hex(MaliciousScoreType.FREEZE)}
-        tx = self._create_register_proposal_tx(proposer, desc, NetworkProposalType.MALICIOUS_SCORE, value)
+        tx = self._create_register_proposal_tx(proposer, title, desc, NetworkProposalType.MALICIOUS_SCORE, value)
         response = self.process_transaction(tx, self.icon_service)
         np_id = response['txHash']
 
@@ -673,9 +682,10 @@ class TestNetworkProposal(IconIntegrateTestBase):
 
         # register proposal - unfreeze SCORE
         proposer = self._test1
+        title = "test title"
         desc = 'Unfreeze malicious SCORE network proposal'
         value = {"address": address, "type": hex(MaliciousScoreType.UNFREEZE)}
-        tx = self._create_register_proposal_tx(proposer, desc, NetworkProposalType.MALICIOUS_SCORE, value)
+        tx = self._create_register_proposal_tx(proposer, title, desc, NetworkProposalType.MALICIOUS_SCORE, value)
         response = self.process_transaction(tx, self.icon_service)
         np_id = response['txHash']
 
@@ -729,9 +739,10 @@ class TestNetworkProposal(IconIntegrateTestBase):
 
         # register proposal - P-Rep disqualification
         proposer = self._test1
+        title = "test title"
         desc = 'P-Rep disqualification network proposal'
         value = {"address": new_prep.get_address()}
-        tx = self._create_register_proposal_tx(proposer, desc, NetworkProposalType.PREP_DISQUALIFICATION, value)
+        tx = self._create_register_proposal_tx(proposer, title, desc, NetworkProposalType.PREP_DISQUALIFICATION, value)
         response = self.process_transaction(tx, self.icon_service)
         np_id = response['txHash']
 
@@ -762,10 +773,11 @@ class TestNetworkProposal(IconIntegrateTestBase):
 
         # register proposal
         proposer = self._test1
+        title = "test title"
         desc = 'step price network proposal'
         step_price = 1000
         value = {"value": hex(step_price)}
-        tx = self._create_register_proposal_tx(proposer, desc, NetworkProposalType.STEP_PRICE, value)
+        tx = self._create_register_proposal_tx(proposer, title, desc, NetworkProposalType.STEP_PRICE, value)
         response = self.process_transaction(tx, self.icon_service)
         np_id = response['txHash']
 


### PR DESCRIPTION
- Support for Tracker 
  - Add `title` param on `registerProposal`
  - Convert name of `getProposalList` to `getProposals`
  - Convert name of param of text proposal from `text` to `value`
  - Convert response format of `getProposals` and `getProposal` as same
- Modify integration and unit tests to support modifications
- Update Readme